### PR TITLE
#120 - Added Modulith component diagrams.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,11 +9,13 @@
 		<groupId>de.tudresden.inf.st.lab</groupId>
 		<artifactId>st-lab-parent</artifactId>
 		<version>2.2.0.RELEASE</version>
+		<relativePath />
 	</parent>
 
 	<properties>
 		<java.version>11</java.version>
 		<salespoint.version>7.2.1.RELEASE</salespoint.version>
+		<moduliths.version>1.0.0.RC3</moduliths.version>
 	</properties>
 
 	<dependencies>
@@ -44,7 +46,7 @@
 
 		<repository>
 			<id>spring-libs-milestone</id>
-			<url>https://repo.spring.io/libs-snapshot</url>
+			<url>https://repo.spring.io/libs-milestone</url>
 		</repository>
 
 		<repository>
@@ -58,7 +60,7 @@
 
 		<pluginRepository>
 			<id>spring-libs-milestone</id>
-			<url>https://repo.spring.io/libs-snapshot</url>
+			<url>https://repo.spring.io/libs-milestone</url>
 		</pluginRepository>
 
 	</pluginRepositories>

--- a/src/test/java/videoshop/VideoshopModularityTests.java
+++ b/src/test/java/videoshop/VideoshopModularityTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 the original author or authors.
+ * Copyright 2018-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,19 +15,68 @@
  */
 package videoshop;
 
+import de.olivergierke.modulith.docs.Documenter;
+import de.olivergierke.modulith.docs.Documenter.Options;
+import de.olivergierke.moduliths.model.Module;
 import de.olivergierke.moduliths.model.Modules;
 
+import java.io.IOException;
+import java.util.Optional;
+import java.util.function.Predicate;
+
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
+import org.springframework.util.StringUtils;
 
 /**
  * Unit test verifying project modularity.
- * 
+ *
  * @author Oliver Gierke
  */
+@TestInstance(Lifecycle.PER_CLASS)
 class VideoshopModularityTests {
+
+	Modules modules = Modules.of(VideoShop.class);
+	Predicate<Module> isSalespointModule = it -> it.getBasePackage().getName().startsWith("org.salespoint");
 
 	@Test
 	void assertModularity() {
-		Modules.of(VideoShop.class).verify();
+		modules.verify();
+	}
+
+	@Test // #120
+	void writeComponentDiagrams() throws IOException {
+
+		Options options = Options.defaults() //
+				.withColorSelector(this::getColorForModule) //
+				.withDefaultDisplayName(this::getModuleDisplayName) //
+				.withTargetOnly(isSalespointModule);
+
+		Documenter documenter = new Documenter(modules);
+		documenter.writeModulesAsPlantUml(options);
+
+		modules.stream().filter(isSalespointModule.negate()) //
+				.forEach(it -> documenter.writeModuleAsPlantUml(it, options));
+	}
+
+	private Optional<String> getColorForModule(Module module) {
+
+		String packageName = module.getBasePackage().getName();
+
+		if (packageName.startsWith("org.salespoint")) {
+			return Optional.of("#ddddff");
+		} else if (packageName.startsWith("videoshop")) {
+			return Optional.of("#ddffdd");
+		} else {
+			return Optional.empty();
+		}
+	}
+
+	private String getModuleDisplayName(Module module) {
+
+		return module.getBasePackage().getName().startsWith("videoshop") //
+				? "Videoshop :: ".concat(StringUtils.capitalize(module.getDisplayName())) //
+				: module.getDisplayName();
 	}
 }


### PR DESCRIPTION
VideoshopModularityTests now contains a test method to create an overall component diagram as well as a module centric one for each of the business modules contained in Videoshop. They can be found in target/generated-docs/moduliths.

Upgrade to Modulith 1.0 RC3, as it exposes new options for coloring and display name customizations.